### PR TITLE
Add Tile.probability field in JSON spec

### DIFF
--- a/docs/reference/json-map-format.rst
+++ b/docs/reference/json-map-format.rst
@@ -526,27 +526,30 @@ Tileset Example
 Tile (Definition)
 ~~~~~~~~~~~~~~~~~
 
-+------------+---------------------+--------------------------------------------+
-| Field      | Type                | Description                                |
-+============+=====================+============================================+
-| animation  | array               | Array of :ref:`Frames <json-frame>`        |
-+------------+---------------------+--------------------------------------------+
-| id         | int                 | Local ID of the tile                       |
-+------------+---------------------+--------------------------------------------+
-| image      | string              | Image representing this tile (optional)    |
-+------------+---------------------+--------------------------------------------+
-| imageheight| int                 | Height of the tile image in pixels         |
-+------------+---------------------+--------------------------------------------+
-| imagewidth | int                 | Width of the tile image in pixels          |
-+------------+---------------------+--------------------------------------------+
-| objectgroup| :ref:`json-layer`   | Layer with type ``objectgroup`` (optional) |
-+------------+---------------------+--------------------------------------------+
-| properties | array               | A list of properties (name, value, type)   |
-+------------+---------------------+--------------------------------------------+
-| terrain    | array               | Index of terrain for each corner of tile   |
-+------------+---------------------+--------------------------------------------+
-| type       | string              | The type of the tile (optional)            |
-+------------+---------------------+--------------------------------------------+
++------------+---------------------+------------------------------------------------+
+| Field      | Type                | Description                                    |
++============+=====================+================================================+
+| animation  | array               | Array of :ref:`Frames <json-frame>`            |
++------------+---------------------+------------------------------------------------+
+| id         | int                 | Local ID of the tile                           |
++------------+---------------------+------------------------------------------------+
+| image      | string              | Image representing this tile (optional)        |
++------------+---------------------+------------------------------------------------+
+| imageheight| int                 | Height of the tile image in pixels             |
++------------+---------------------+------------------------------------------------+
+| imagewidth | int                 | Width of the tile image in pixels              |
++------------+---------------------+------------------------------------------------+
+| objectgroup| :ref:`json-layer`   | Layer with type ``objectgroup`` (optional)     |
++------------+---------------------+------------------------------------------------+
+| probability| double              | Percentage chance this tile is chosen when     |
+|            |                     | competing with others in the editor (optional) |
++------------+---------------------+------------------------------------------------+
+| properties | array               | A list of properties (name, value, type)       |
++------------+---------------------+------------------------------------------------+
+| terrain    | array               | Index of terrain for each corner of tile       |
++------------+---------------------+------------------------------------------------+
+| type       | string              | The type of the tile (optional)                |
++------------+---------------------+------------------------------------------------+
 
 A tileset that associates information with each tile, like its image
 path or terrain type, may include a ``tiles`` array property. Each tile


### PR DESCRIPTION
While parsing some of the example files, I noticed this field was in the exported file but not in my parsing. I don't know if it's all that relevant for a non-editor (since it says this is used in by the editor) but since it can be in the file it seems like it should be listed for completeness.